### PR TITLE
Issues 43

### DIFF
--- a/client/src/components/examView/ExamList.js
+++ b/client/src/components/examView/ExamList.js
@@ -60,11 +60,22 @@ export default class ExamList extends Component {
       newExam[0].courseName = this.state.newName;
     }
     if (this.state.newCourseNumber !== undefined && this.state.newCourseNumber !== '') {
-      newExam[0].courseNumber = this.state.newCourseNumber;
+        if (this.state.newCourseNumber.match(/^[0-9]+$/) != null) { //check if string is a number
+            newExam[0].courseNumber = this.state.newCourseNumber;
+        }
+        else {
+            console.log('CourseNumber must be made of digits.');
+            alert("Invalid Course Number. Please enter digits only.");
+        }
     }
     if (this.state.newTimeLimit !== undefined && this.state.newTimeLimit !== '') {
-      console.log('hi');
-      newExam[0].timeLimit = this.state.newTimeLimit;
+        if (this.state.newTimeLimit.match(/^[0-9]+$/) != null) { //check if string is a number
+            newExam[0].timeLimit = this.state.newTimeLimit;
+        }
+        else {
+            console.log('CourseNumber must be made of digits.');
+            alert("Invalid Course Number. Please enter digits only.");
+        }
     }
     // FIX: need to update questionList as well
 
@@ -76,7 +87,7 @@ export default class ExamList extends Component {
         },
         body: JSON.stringify(this.state.exam),
       })
-        .then(alert('The test is updated.'))
+        .then(alert('The test is updated. Please refresh the page to see the updated test.'))
         .then(console.log(this.state.exam))
         .catch(error => console.error('fetch error at shuffleExam', error));
     });


### PR DESCRIPTION
Added additional front-end warning to user and an additional constraints on the back-end for both Course Number and Time Limit in the Exam List tab.
----------------------------------------------------------------------------------------------------------------
Original Error:
Summary: Changing course number to letters deleted all tests.

Description: I tried editing a new test by changing the course number to letters. The system allowed this and said I successfully updated the test. Git bash said reported that the app crashed - waiting for file changes before restarting followed by a proxy error. There is no indication of this on the front end. When I refreshed the page, all tests were missing, new tests could not be created, and exams couldn’t be taken.

Severity: Critical

Suggestions/Comments: The website is pretty much broken at this point from what occurred. Make absolute certain to prevent users from entering letters into the course number field in a similar way that you handle time limits for tests. It would also be wise to do error checking in the backend. If the received data isn’t an integer, stop and throw an error to the user before allowing the system to crash.


